### PR TITLE
Poet 0.x - Moodle coding guideline fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: php
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+php:
+ - 5.6
+ - 7.0
+
+env:
+ global:
+  - MOODLE_BRANCH=MOODLE_30_STABLE
+
+ matrix:
+  - DB=pgsql
+  - DB=mysqli
+
+before_install:
+  - phpenv config-rm xdebug.ini
+  - cd ../..
+  - composer selfupdate
+  - composer create-project -n --no-dev moodlerooms/moodle-plugin-ci ci ^1
+  - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
+
+install:
+  - moodle-plugin-ci install
+
+script:
+  - moodle-plugin-ci phplint
+  - moodle-plugin-ci phpcpd
+  - moodle-plugin-ci phpmd
+  - moodle-plugin-ci codechecker
+  - moodle-plugin-ci csslint
+  - moodle-plugin-ci shifter
+  - moodle-plugin-ci jshint
+  - moodle-plugin-ci validate
+  - moodle-plugin-ci phpunit
+  - moodle-plugin-ci behat


### PR DESCRIPTION
Hi -
I ran the plugin through the Moodle Plugin Standard (as well as others), to help it meet coding issues ahead of release. This pull has the fixes that can be automatically fixed using the tools at hand.
The first test is here - https://travis-ci.org/POETGroup/moodle-mod_hvp/builds/119624232
And the latest with these fixes, as well as removing the "library" subdirectory from the testing (since it is an outside library not subject to Moodle coding standards) is here - https://travis-ci.org/POETGroup/moodle-mod_hvp/builds/119637615
The only parts that are really important are in the section after the line "$ moodle-plugin-ci codechecker".
In the structure validation test ($ moodle-plugin-ci validate), you'll also notice there is a missing language string.
Let me know if you are willing to accept these coding guideline changes, and I will also offer my help making the other fixes that cannot be provided automatically.