### PR TITLE
Fix missing encode_content_links on backup_hvp_activity_task.class

### DIFF
--- a/backup/moodle2/backup_hvp_activity_task.class.php
+++ b/backup/moodle2/backup_hvp_activity_task.class.php
@@ -45,4 +45,26 @@ class backup_hvp_activity_task extends backup_activity_task {
     protected function define_my_steps() {
         // $this->add_step(new backup_hvp_activity_structure_step('hvp_structure', 'hvp.xml'));
     }
+    
+    /**
+     * Encodes URLs to the index.php and view.php scripts
+     *
+     * @param string $content some HTML text that eventually contains URLs to the activity instance scripts
+     * @return string the content with the URLs encoded
+     */
+    static public function encode_content_links($content) {
+        global $CFG;
+
+        $base = preg_quote($CFG->wwwroot,"/");
+
+        // Link to the list of glossaries
+        $search="/(".$base."\/mod\/hvp\/index.php\?id\=)([0-9]+)/";
+        $content= preg_replace($search, '$@HVPINDEX*$2@$', $content);
+
+        // Link to hvp view by moduleid
+        $search="/(".$base."\/mod\/hvp\/view.php\?id\=)([0-9]+)/";
+        $content= preg_replace($search, '$@HVPVIEWBYID*$2@$', $content);
+
+        return $content;
+    }
 }


### PR DESCRIPTION
Was unable to backup activity and was also breaking full course backup,
if user was using hvp activity in course.

Patch, fixes above issue.