### PR TITLE
Display title on mod view page

### DIFF
--- a/view.php
+++ b/view.php
@@ -142,6 +142,7 @@ $PAGE->requires->data_for_js('H5PIntegration', $settings, true);
 
 // Print page HTML.
 echo $OUTPUT->header();
+echo $OUTPUT->heading(format_string($content['title']));
 echo '<div class="clearer"></div>';
 
 // Print any messages.


### PR DESCRIPTION
It's conventional in Moodle activities to display the title of the activity above the description.

Some activities (e.g. page) will offer an option to enable/disable this behaviour; I'd be happy to implement this if preferred.