### PR TITLE
Enabled overriding styles and scripts from the theme

### DIFF
--- a/classes/framework.php
+++ b/classes/framework.php
@@ -960,7 +960,7 @@ class framework implements \H5PFrameworkInterface {
         $dependencies = array();
         foreach ($data as $dependency) {
             unset($dependency->unidepid);
-            $dependencies[] = \H5PCore::snakeToCamel($dependency);
+            $dependencies[$dependency->machine_name] = \H5PCore::snakeToCamel($dependency);
         }
 
         return $dependencies;

--- a/renderer.php
+++ b/renderer.php
@@ -1,0 +1,68 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Defines the renderer for the hvp (H5P) module.
+ *
+ * @package     mod_hvp
+ * @copyright   2016 onward Eiz Edddin Al Katrib <eiz@barasoft.co.uk>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * The renderer for the hvp module.
+ *
+ * @copyright   2016 onward Eiz Edddin Al Katrib <eiz@barasoft.co.uk>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class mod_hvp_renderer extends plugin_renderer_base {
+
+    /**
+    * Return additional asset files to the libraries.
+    *
+    * @param array $libraries Array of libraries indexed by the library's machineName
+    * @return array
+    */
+    public function hvp_additional_asset_files($libraries) {
+        return array (
+            'styles' => $this->hvp_add_styles($libraries),
+            'scripts' => $this->hvp_add_scripts($libraries)
+        );
+    }
+
+    /**
+    * Return additional style files to the libraries.
+    *
+    * @param array $libraries Array of libraries indexed by the library's machineName
+    * @return array Array of objects with properties path and version.
+    */
+    public function hvp_add_styles($libraries) {
+        return array();
+    }
+
+    /**
+    * Return additional script files to the libraries.
+    *
+    * @param array $libraries Array of libraries indexed by the library's machineName
+    * @return array Array of objects with properties path and version.
+    */
+    public function hvp_add_scripts($libraries) {
+        return array();
+    }
+
+}

--- a/view.php
+++ b/view.php
@@ -105,6 +105,11 @@ $settings['contents'][$cid] = array(
 $preloadeddependencies = $core->loadContentDependencies($content['id'], 'preloaded');
 $files = $core->getDependenciesFiles($preloadeddependencies);
 
+// Add additional asset files if required.
+$hvpoutput = $PAGE->get_renderer('mod_hvp');
+$additionalfiles= $hvpoutput->hvp_additional_asset_files($preloadeddependencies);
+$files = array_merge_recursive($files, $additionalfiles);
+
 // Determine embed type.
 $embedtype = \H5PCore::determineEmbedType($content['embedType'], $content['library']['embedTypes']);
 if ($embedtype === 'div') {


### PR DESCRIPTION
This patch enables overriding the libraries styles and scripts from the theme's renderer.

This is with reference to #12, and it implements a similar functionality as in https://h5p.org/documentation/for-developers/visual-changes.

To override any library's styles and scripts, you will need to:

1. Create a file **mod_hvp_renderer.php** in your theme in the following directory {themename}/classes/
2. Create the following class in the above file to override the plugin's renderer:
```
class theme_{themename}_mod_hvp_renderer extends mod_hvp_renderer {

}
```
3. Add the following overriding method in the above class (as an example to add an overriding css file for the CoursePresentation library) 
```
  public function hvp_add_styles($libraries) {
        global $CFG;
        $styles = array();
        if (isset($libraries['H5P.CoursePresentation']) && $libraries['H5P.CoursePresentation']['majorVersion'] == '1') {
            $styles[] = (object) array(
                'path' => $CFG->httpswwwroot.'/theme/{themename}/style/h5p_cp_overrides.css',
                'version' => '',
            )
        }
        return $styles;
    }
```
4. To add a js file, you can use the following method **hvp_add_scripts($libraries)**, in the same way as above.

Please refer to the following Moodle dev docs for more details regarding overriding a renderer https://docs.moodle.org/dev/Overriding_a_renderer. 