### PR TITLE
Fix failing to download H5P using download button.

### DIFF
--- a/classes/framework.php
+++ b/classes/framework.php
@@ -936,7 +936,10 @@ class framework implements \H5PFrameworkInterface {
      */
     public function loadContent($id) {
         global $DB;
-
+        if (!is_numeric($id)) {
+          $id = explode('.', $id);
+          $id = $id[0];
+        }
         $data = $DB->get_record_sql(
                 "SELECT hc.id
                       , hc.name


### PR DESCRIPTION
Hi,

While trying to do a backup of some of our H5P's we discovered that the download was failing because the id being used in the database query still had the '.h5p' on the end of it. The changes in this commit fixed the issue for our Moodle but will need some testing.

Thanks,
Carl