### PR TITLE
Make Name field required.

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -35,6 +35,7 @@ class mod_hvp_mod_form extends moodleform_mod {
         // Name.
         $mform->addElement('text', 'name', get_string('name'));
         $mform->setType('name', PARAM_TEXT);
+        $mform->addRule('name', null, 'required', null, 'client');
         $mform->addRule('name', get_string('maximumchars', '', 255), 'maxlength', 255, 'client');
 
         // Intro.


### PR DESCRIPTION
We made a minor changed to make it obvious that Name is a required field. Right now, you do get an error if Name isn't set, but it isn't labeled red with a star indicating that it is a required field when you initially create the form.