### PR TITLE
Deleting the duplicate language string found for invalidlibrary.

### DIFF
--- a/lang/en/hvp.php
+++ b/lang/en/hvp.php
@@ -269,4 +269,3 @@ $string['welcomecommunity'] = 'We hope you will enjoy H5P and get engaged in our
 $string['welcomecontactus'] = 'If you have any feedback, don\'t hesitate to <a {$a}>contact us</a>. We take feedback very seriously and are dedicated to making H5P better every day!';
 $string['missingmbstring'] = 'The mbstring PHP extension is not loaded. H5P need this to function properly';
 $string['wrongversion'] = 'The version of the H5P library {$a->%machineName} used in this content is not valid. Content contains {$a->%contentLibrary}, but it should be {$a->%semanticsLibrary}.';
-$string['invalidlibrary'] = 'The H5P library {$a->%library} used in the content is not valid';


### PR DESCRIPTION
There is a duplicate entry for 'invalidlibrary'. It is causing the error message "The H5P library {$a->%library} used in the content is not valid" to be displayed instead of "Invalid library."

The {$a->%library} placeholder is never filled.