### PR TITLE
Fixed bug when downloading file

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -284,7 +284,7 @@ function hvp_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload
               return false;
             }
 
-            $contentid = $matches[0];
+            $contentid = $matches[1];
             $content = $h5pinterface->loadContent($contentid);
             $displayOptions = $h5pcore->getDisplayOptionsForView($content['disable'], $contentid);
 


### PR DESCRIPTION
When viewing an activity, the Download button is not working correctly. It returns the following error:

```
Debug info: ORA-01722: invalid number
SELECT hc.id 
, hc.name 
, hc.intro 
, hc.introformat 
, hc.json_content 
, hc.filtered 
, hc.slug 
, hc.embed_type 
, hc.disable 
, hl.id AS library_id 
, hl.machine_name 
, hl.major_version 
, hl.minor_version 
, hl.embed_types 
, hl.fullscreen 
FROM m2hvp hc 
JOIN m2hvp_libraries hl ON hl.id = hc.main_library_id 
WHERE hc.id = :o_param1
[array (
'o_param1' => '1.h5p',
)]
Error code: dmlreadexception
  × Stack trace:
line 479 of /lib/dml/moodle_database.php: dml_read_exception thrown
line 282 of /lib/dml/oci_native_moodle_database.php: call to moodle_database->query_end()
line 1207 of /lib/dml/oci_native_moodle_database.php: call to oci_native_moodle_database->query_end()
line 1551 of /lib/dml/moodle_database.php: call to oci_native_moodle_database->get_records_sql()
line 1137 of /lib/dml/oci_native_moodle_database.php: call to moodle_database->get_record_sql()
line 912 of /mod/hvp/classes/framework.php: call to oci_native_moodle_database->get_record_sql()
line 288 of /mod/hvp/lib.php: call to mod_hvp\framework->loadContent()
line 4618 of /lib/filelib.php: call to hvp_pluginfile()
line 37 of /pluginfile.php: call to file_pluginfile()
```

It can be fixed with the following patch.
