### PR TITLE
Set height and width of the SVG -icon to 24px.

### DIFF
--- a/pix/icon.svg
+++ b/pix/icon.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 1000 1000" style="enable-background:new 0 0 1000 1000;" xml:space="preserve">
+	 viewBox="0 0 1000 1000" width="24" height="24" style="enable-background:new 0 0 1000 1000;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:#1D1D1D;}
 	.st1{fill:#FFFFFF;}


### PR DESCRIPTION
This fixes the activity icon on browsers/environments using SVG -icons. Issue is similiar to https://github.com/h5p/h5p-moodle-plugin/pull/97
