### PR TITLE
Permit visitor access to H5P resources.

### DIFF
--- a/view.php
+++ b/view.php
@@ -36,7 +36,7 @@ $course = $DB->get_record('course', array('id' => $cm->course));
 if (!$course) {
     print_error('coursemisconf');
 }
-require_course_login($course, false, $cm);
+require_course_login($course, true, $cm);
 $context = context_module::instance($cm->id);
 require_capability('mod/hvp:view', $context);
 


### PR DESCRIPTION
Currently, there is a slight difficulty making H5P available 
via Moodle on the open Web. Moodle allows "guest" access
automatically, but the H5P module doesn't honor this setting.

With this change, if the Moodle site is configured to log in guests
automatically, *and* if the course is configured to
allow guest acesses, this will make Moodle-hosted H5P
resources available on the open Web, as everybody
expects and wants.

I have tested this and it works as expected. Also, this 
is what mod/resource/view.php does, and I don't see
any reason H5P resources should work any differently
from files in this respect.
  