### PR TITLE
HFP-1786 Updates pointers for embedded content when copying

### DIFF
--- a/backup/moodle2/backup_hvp_activity_task.class.php
+++ b/backup/moodle2/backup_hvp_activity_task.class.php
@@ -78,6 +78,10 @@ class backup_hvp_activity_task extends backup_activity_task {
         $search = "/(".$base."\/mod\/hvp\/view.php\?id\=)([0-9]+)/";
         $content = preg_replace($search, '$@HVPVIEWBYID*$2@$', $content);
 
+        // Link to hvp embed by module id.
+        $search = "/(".$base."\/mod\/hvp\/embed.php\?id\=)([0-9]+)/";
+        $content = preg_replace($search, '$@HVPEMBEDBYID*$2@$', $content);
+
         return $content;
     }
 }

--- a/backup/moodle2/restore_hvp_activity_task.class.php
+++ b/backup/moodle2/restore_hvp_activity_task.class.php
@@ -72,6 +72,7 @@ class restore_hvp_activity_task extends restore_activity_task {
 
         $rules[] = new restore_decode_rule('HVPVIEWBYID', '/mod/hvp/view.php?id=$1', 'course_module');
         $rules[] = new restore_decode_rule('HVPINDEX', '/mod/hvp/index.php?id=$1', 'course');
+        $rules[] = new restore_decode_rule('HVPEMBEDBYID', '/mod/hvp/embed.php?id=$1', 'course_module');
 
         return $rules;
     }


### PR DESCRIPTION
These are the changes I described in [my comment](https://github.com/h5p/h5p-moodle-plugin/issues/184#issuecomment-353069531). When a course is copied, the embedded H5P activities in the copied course point to the copied H5P activities. See also [HFP-1786 Moodle embed: Copying embedded content must update pointers](https://h5ptechnology.atlassian.net/browse/HFP-1786).