### PR TITLE
added crossoriginRegex setting

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -74,6 +74,7 @@ function hvp_get_core_settings($context) {
         'hubIsEnabled' => get_config('mod_hvp', 'hub_is_enabled') ? true : false,
         'reportingIsEnabled' => true,
         'crossorigin' => isset($CFG->mod_hvp_crossorigin) ? $CFG->mod_hvp_crossorigin : null,
+        'crossoriginRegex' => isset($CFG->mod_hvp_crossoriginRegex) ? $CFG->mod_hvp_crossoriginRegex : null,
         'libraryConfig' => $core->h5pF->getLibraryConfig(),
     );
 


### PR DESCRIPTION
The ```H5PIntegration``` object is expected to have the property ```crossoriginRegex``` in [h5p.json here](https://github.com/h5p/h5p-php-library/blob/c2d7b987cc971c5be1553da1ae84e93d1cc019b7/js/h5p.js#L2036), but this property is never set. This seems to be an omission and I've added it to the plugin.