### PR TITLE
Display correct user grades on Results table page

### DIFF
--- a/classes/results.php
+++ b/classes/results.php
@@ -194,8 +194,8 @@ class results {
 
         // Join on xAPI results.
         $join .= ' LEFT JOIN {hvp_xapi_results} x ON i.iteminstance = x.content_id';
-        $join .= " LEFT JOIN {user} u ON u.id = x.user_id";
-        $groupby = ' GROUP BY i.id, g.id, u.id, i.iteminstance, x.id';
+        $join .= " LEFT JOIN {user} u ON u.id = g.userid";
+        $groupby = ' GROUP BY i.id, g.id, u.id, i.iteminstance';
 
         // Get from statement.
         $from = $this->get_from_sql();


### PR DESCRIPTION
No user grades where displayed on grade table,
And after clicking the "sort" column by "grade", all grades of the last user on the list where displayed overwriting each other user on the table.

Suggested fix seems to solve this issue.
Please review and see if you can integrate.

Kindly,
Nadav