### PR TITLE
Enabling search in moodle h5p result table

### DIFF
--- a/classes/results.php
+++ b/classes/results.php
@@ -320,7 +320,7 @@ class results {
      * @param int $uid Only get users with this id
      * @return array $fields, $join, $where, $order, $args
      */
-    protected function get_content_sql($uid=null, $for_count=null) {
+    protected function get_content_sql($uid=null, $forcount=null) {
         global $DB;
 
         $usernamefields = implode(', ', self::get_ordered_user_name_fields());
@@ -335,7 +335,7 @@ class results {
             array_push($args, $uid);
         }
 
-        if (isset($this->filters[0]) && !($for_count)) {
+        if (isset($this->filters[0]) && !($forcount)) {
             $keywordswhere = array();
 
             // Split up keywords using whitespace and comma.

--- a/classes/results.php
+++ b/classes/results.php
@@ -233,7 +233,7 @@ class results {
     protected function get_results_num() {
         global $DB;
 
-        list(, $join, $where, , $args) = $this->get_content_sql();
+        list(, $join, $where, , $args) = $this->get_content_sql(null, 1);
         $where[] = "i.itemtype = 'mod'";
         $where[] = "i.itemmodule = 'hvp'";
         $where = 'WHERE ' . implode(' AND ', $where);
@@ -320,7 +320,7 @@ class results {
      * @param int $uid Only get users with this id
      * @return array $fields, $join, $where, $order, $args
      */
-    protected function get_content_sql($uid=null) {
+    protected function get_content_sql($uid=null, $for_count=null) {
         global $DB;
 
         $usernamefields = implode(', ', self::get_ordered_user_name_fields());
@@ -335,7 +335,7 @@ class results {
             array_push($args, $uid);
         }
 
-        if (isset($this->filters[0])) {
+        if (isset($this->filters[0]) && !($for_count)) {
             $keywordswhere = array();
 
             // Split up keywords using whitespace and comma.


### PR DESCRIPTION
After typing search parameter in the search input on top of the result table page and change focus the table is emptied.
An sql error is raised due to where clause parameters that are not included in the select fields.
Suggesting to add an extra parameter to "get_content_sql" function in order to differentiate  between where clause in count/content queries in order solve the problem.
Please review the addition in code and see if you would like to integrate them.
.