### PR TITLE
implements passing grade course completion

### DIFF
--- a/backup/moodle2/backup_hvp_stepslib.php
+++ b/backup/moodle2/backup_hvp_stepslib.php
@@ -68,7 +68,8 @@ class backup_hvp_activity_structure_step extends backup_activity_structure_step 
             'timecreated',
             'timemodified',
             'authors',
-            'license'
+            'license',
+            'completionpass'
         ));
 
         // User data.
@@ -114,7 +115,8 @@ class backup_hvp_activity_structure_step extends backup_activity_structure_step 
                  h.changes,
                  h.license_extras,
                  h.author_comments,
-                 h.license
+                 h.license,
+                 h.completionpass
           FROM {hvp} h
               JOIN {hvp_libraries} hl ON hl.id = h.main_library_id
               WHERE h.id = ?', array(backup::VAR_ACTIVITYID));

--- a/classes/framework.php
+++ b/classes/framework.php
@@ -948,6 +948,10 @@ class framework implements \H5PFrameworkInterface {
             'timemodified' => time(),
         ));
 
+        if( isset( $content[ 'completionpass' ] ) ){
+            $data[ 'completionpass' ] = $content[ 'completionpass' ];
+        }
+
         if (!isset($content['id'])) {
             $data['slug'] = '';
             $data['timecreated'] = $data['timemodified'];

--- a/classes/user_grades.php
+++ b/classes/user_grades.php
@@ -34,7 +34,7 @@ require(__DIR__ . '/../lib.php');
 class user_grades {
 
     public static function handle_ajax() {
-        global $DB, $USER;
+        global $DB, $USER, $CFG;
 
         if (!\H5PCore::validToken('result', required_param('token', PARAM_RAW))) {
             \H5PCore::ajaxError(get_string('invalidtoken', 'hvp'));
@@ -88,6 +88,16 @@ class user_grades {
                   WHERE c.id = ?",
                 array($hvp->id)
         );
+
+        require_once($CFG->libdir.'/completionlib.php');
+
+        // Load Course.
+        $course = $DB->get_record('course', array('id' => $cm->course));
+        $completion = new \completion_info( $course );
+
+        if ( $completion->is_enabled( $cm) ) {
+            $completion->update_state($cm,COMPLETION_COMPLETE);
+        }
 
         // Log results set event.
         new \mod_hvp\event(

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/hvp/db" VERSION="20180831" COMMENT="XMLDB file for Moodle mod/hvp"
+<XMLDB PATH="mod/hvp/db" VERSION="20190731" COMMENT="XMLDB file for Moodle mod/hvp"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -30,6 +30,7 @@
         <FIELD NAME="slug" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" COMMENT="Human readable content identifier that is unique"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="completionpass" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -481,6 +481,20 @@ function hvp_upgrade_2019030700() {
     }
 }
 
+function hvp_upgrade_2019073101(){
+    global $DB;
+    $dbman = $DB->get_manager();
+    // Define field completionscorerequired to be added to hvp.
+    $table = new xmldb_table('hvp');
+    // Conditionally launch add field completionscorerequired.
+    if (!$dbman->field_exists($table, 'completionpass')) {
+        $dbman->add_field(
+            $table,
+            new xmldb_field('completionpass', XMLDB_TYPE_INTEGER, '1', null, null, null, 0, 'timemodified')
+        );
+    }
+}
+
 /**
  * Hvp module upgrade function.
  *
@@ -501,7 +515,8 @@ function xmldb_hvp_upgrade($oldversion) {
         2017060900,
         2018090300,
         2019022600,
-        2019030700
+        2019030700,
+        2019073101
     ];
 
     foreach ($upgrades as $version) {

--- a/lang/en/hvp.php
+++ b/lang/en/hvp.php
@@ -441,3 +441,9 @@ $string['offlineDialogBody'] = 'We were unable to send information about your co
 $string['offlineDialogRetryMessage'] = 'Retrying in :num....';
 $string['offlineDialogRetryButtonLabel'] = 'Retry now';
 $string['offlineSuccessfulSubmit'] = 'Successfully submitted results.';
+
+$string['completionpass'] = 'Require passing grade';
+$string['completionpassdesc'] = 'Student must achieve a passing grade to complete this activity';
+$string['completionpass_help'] = 'If enabled, this activity is considered complete when the student receives a pass grade (as specified in the Grade section of the H5P activity settings) or higher.';
+$string['gradetopassnotset'] = 'This H5P activity does not yet have a grade to pass set. It may be set in the Grade section of the H5P activity settings.';
+$string['gradetopassmustbeset'] = 'Grade to pass cannot be zero as this H5P activity has its completion method set to require passing grade. Please set a non-zero value.';

--- a/lib.php
+++ b/lib.php
@@ -55,7 +55,7 @@ function hvp_supports($feature) {
         case FEATURE_COMPLETION_TRACKS_VIEWS:
             return true;
         case FEATURE_COMPLETION_HAS_RULES:
-            return false;
+            return true;
         case FEATURE_GRADE_HAS_GRADE:
             return true;
         case FEATURE_GRADE_OUTCOMES:
@@ -386,3 +386,35 @@ function hvp_update_grades($hvp=null, $userid=0, $nullifnone=true) {
         hvp_grade_item_update($hvp);
     }
 }
+
+/**
+ * Obtains the automatic completion state for this H5P activity on any conditions
+ * in settings, such as if a certain grade is achieved.
+ *
+ * @param object $course Course
+ * @param object $cm Course-module
+ * @param int $userid User ID
+ * @param bool $type Type of comparison (or/and; can be used as return value if no conditions)
+ * @return bool True if completed, false if not. (If no conditions, then return
+ *   value depends on comparison type)
+ */
+function hvp_get_completion_state($course, $cm, $userid, $type) {
+    global $DB, $CFG;
+    $hvp = $DB->get_record('hvp', array('id' => $cm->instance), '*', MUST_EXIST);
+    if (!$hvp->completionpass) {
+        return $type;
+    }
+    // Check for passing grade.
+    if ($hvp->completionpass) {
+        require_once($CFG->libdir . '/gradelib.php');
+        $item = grade_item::fetch(array('courseid' => $course->id, 'itemtype' => 'mod',
+                'itemmodule' => 'hvp', 'iteminstance' => $cm->instance, 'outcomeid' => null));
+        if ($item) {
+            $grades = grade_grade::fetch_users_grades($item, array($userid), false);
+            if (!empty($grades[$userid])) {
+                return $grades[$userid]->is_passed($item);
+            }
+        }
+    }
+    return false;
+} 

--- a/mod_form.php
+++ b/mod_form.php
@@ -208,6 +208,11 @@ class mod_hvp_mod_form extends moodleform_mod {
         }
         $defaultvalues['h5pparams'] = json_encode($maincontentdata, true);
 
+        // Completion settings check.
+        if (empty($defaultvalues['completionusegrade'])) {
+            $defaultvalues['completionpass'] = 0; // Forced unchecked.
+        }
+
         // Add required editor assets.
         require_once('locallib.php');
         $mformid = $this->_form->getAttribute('id');
@@ -332,6 +337,19 @@ class mod_hvp_mod_form extends moodleform_mod {
         } else {
             $this->validate_created($data, $errors);
         }
+
+        if (array_key_exists('completion', $data) && $data['completion'] == COMPLETION_TRACKING_AUTOMATIC) {
+            $completionpass = isset($data['completionpass']) ? $data['completionpass'] : $this->current->completionpass;
+            // Show an error if require passing grade was selected and the grade to pass was set to 0.
+            if ($completionpass && (empty($data['gradepass']) || grade_floatval($data['gradepass']) == 0)) {
+                if (isset($data['completionpass'])) {
+                    $errors['completionpassgroup'] = get_string('gradetopassnotset', 'hvp');
+                } else {
+                    $errors['gradepass'] = get_string('gradetopassmustbeset', 'hvp');
+                }
+            }
+        }
+
         return $errors;
     }
 
@@ -409,5 +427,18 @@ class mod_hvp_mod_form extends moodleform_mod {
             }
         }
         return $data;
+    }
+    
+    public function add_completion_rules() {
+        $mform =& $this->_form;
+        $items = array();
+        $group = array();
+        $group[] = $mform->createElement('advcheckbox', 'completionpass', null, get_string('completionpass', 'hvp'),
+                array('group' => 'cpass'));
+        $mform->disabledIf('completionpass', 'completionusegrade', 'notchecked');
+        $mform->addGroup($group, 'completionpassgroup', get_string('completionpass', 'hvp'), ' &nbsp; ', false);
+        $mform->addHelpButton('completionpassgroup', 'completionpass', 'hvp');
+        $items[] = 'completionpassgroup';
+        return $items;
     }
 }

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2019031301;
+$plugin->version   = 2019073101;
 $plugin->requires  = 2013051403;
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';


### PR DESCRIPTION
Address #163. This PR introduces course completion akin to the Quiz Activity as described here; https://docs.moodle.org/37/en/Activity_completion_settings#Require_grade.

It introduces an additional condition to completion tracking, "Require passing grade" (tick box), which if checked alongside "Require grade" ensures that the activity is only marked as completed once the  "Grade to pass" as defined in the Grade section of the H5P activity settings has been achieved.

So, to test, simply do as indicated above and ensure that the activity is not marked as completed if the total activity score is less than "Grade to pass" and conversely is marked as completed if the total activity score is greater than or equal to "Grade to pass".

With this PR performing the steps as described in the original issue here; https://github.com/h5p/h5p-moodle-plugin/issues/163#issue-239378343, whilst ensuring that the newly introduced "Require passing grade" (tick box) is checked as indicated above, the correct outcome should now be yielded.