### PR TITLE
Fix translation strings that was not mappable to stop crashing

### DIFF
--- a/classes/framework.php
+++ b/classes/framework.php
@@ -485,6 +485,13 @@ class framework implements \H5PFrameworkInterface {
             // @codingStandardsIgnoreEnd
         }
 
+        // Some strings such as error messages are not translatable, in this case use message
+        // directly instead of crashing
+        // @see https://github.com/h5p/h5p-php-library/commit/2bd972168e7b22aaeea2dd13682ced9cf8233452#diff-5ca86cd0514d58be6708beff914aba66R1296
+        if (!isset($translationsmap[$message])) {
+            return $message;
+        }
+
         return get_string($translationsmap[$message], 'hvp', $replacements);
     }
 


### PR DESCRIPTION
Examples of untranslatable/unmappable strings that was crashing are error messages such as in https://github.com/h5p/h5p-php-library/commit/2bd972168e7b22aaeea2dd13682ced9cf8233452#diff-5ca86cd0514d58be6708beff914aba66R1296
These should probably not have been run through the translation interface at all