### PR TITLE
Fix dmlwriteexception error by changing lang/en/hvp.php

### DIFF
--- a/lang/en/hvp.php
+++ b/lang/en/hvp.php
@@ -430,9 +430,9 @@ $string['privacy:metadata:hvp_xapi_results:max_score'] = 'Max achievable score f
 
 // Reuse.
 $string['reuse'] = 'Reuse';
-$string['reusecontent'] = 'Reuse Content';
-$string['reusedescription'] = 'Reuse this content.';
-$string['contentcopied'] = 'Content is copied to the clipboard';
+$string['reusecontent1'] = 'Reuse Content';
+$string['reusedescription1'] = 'Reuse this content.';
+$string['contentcopied1'] = 'Content is copied to the clipboard';
 
 // Offline
 $string['connectionlost'] = 'Connection lost. Results will be stored and sent when you regain connection.';


### PR DESCRIPTION
should fix debug messages such as: 
`Debug info: Duplicate entry 'en-447-reusecontent' for key 'mdl_toolcust_lancomstr_uix'
INSERT INTO mdl_tool_customlang (lang,componentid,stringid,original,master,timemodified,outdated,local,timecustomized) VALUES(?,?,?,?,?,?,?,?,?)
[array (
0 => 'en',
1 => '447',
2 => 'reusecontent',
3 => 'Reuse Content',
4 => 'Reuse Content',
5 => 1585019390,
6 => 0,
7 => NULL,
8 => NULL,
)]
Error code: dmlwriteexception `

Should fix issue #313 