### PR TITLE
Fix dmlwriteexception error in language customisation by removing dup…

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -482,6 +482,31 @@ function hvp_upgrade_2019030700() {
 }
 
 /**
+ * Update uppercase language strings with lowercase in the table tool_customlang
+ *
+ * @throws ddl_exception
+ */
+function hvp_upgrade_2020042200() {
+    global $DB;
+    $dbman = $DB->get_manager();
+
+    $table = 'tool_customlang';
+    $select = 'stringid = :stringid';
+
+    $reusecontentrecord = $DB->get_record($table, ['stringid' => 'reuseContent']);
+    $reusecontentrecord->stringid = 'reusecontent';
+    $DB->update_record($table, $reusecontentrecord);
+
+    $reusedescriptionrecord = $DB->get_record($table, ['stringid' => 'reuseDescription']);
+    $reusedescriptionrecord->stringid = 'reusedescription';
+    $DB->update_record($table, $reusedescriptionrecord);
+
+    $contentcopiedrecord = $DB->get_record($table, ['stringid' => 'contentCopied']);
+    $contentcopiedrecord->stringid = 'contentcopied';
+    $DB->update_record($table, $contentcopiedrecord);
+}
+
+/**
  * Hvp module upgrade function.
  *
  * @param string $oldversion The version we are upgrading from
@@ -501,7 +526,8 @@ function xmldb_hvp_upgrade($oldversion) {
         2017060900,
         2018090300,
         2019022600,
-        2019030700
+        2019030700,
+        2020042200,
     ];
 
     foreach ($upgrades as $version) {

--- a/version.php
+++ b/version.php
@@ -23,9 +23,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020020500;
+$plugin->version   = 2020042200;
 $plugin->requires  = 2013051403;
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '1.20.2';
+$plugin->release   = '1.20.3';


### PR DESCRIPTION
Hi,

Can anyone review this and merge?

Issue: Throwing dmlwriteexception error in language customisation settings due to the duplicate language strings having uppercase.

Fix: Removed the records from the table tool_customlang where duplicate language strings having uppercase. Only below strings have the duplicate upper case issues.
* reuseContent
* reuseDescription
* contentCopied

Please review and let me know if there are any issues.

Thanks,
Anu