### PR TITLE
Issue #336: Fix dmlwriteexception error in language customisation

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -482,6 +482,34 @@ function hvp_upgrade_2019030700() {
 }
 
 /**
+ * Update uppercase language strings with lowercase in the table tool_customlang.
+ *
+ * @throws ddl_exception
+ */
+function hvp_upgrade_2020042200() {
+    global $DB;
+    $dbman = $DB->get_manager();
+
+    $table = 'tool_customlang';
+    $select = 'stringid = :stringid';
+
+    // Update string "reuseContent" with "reusecontent" because of the string change in the commit e3e3400.
+    $reusecontentrecord = $DB->get_record($table, ['stringid' => 'reuseContent']);
+    $reusecontentrecord->stringid = 'reusecontent';
+    $DB->update_record($table, $reusecontentrecord);
+
+    // Update string "reuseDescription" with "reusedescription" because of the string change in the commit e3e3400.
+    $reusedescriptionrecord = $DB->get_record($table, ['stringid' => 'reuseDescription']);
+    $reusedescriptionrecord->stringid = 'reusedescription';
+    $DB->update_record($table, $reusedescriptionrecord);
+
+    // Update string "contentCopied" with "contentcopied" because of the string change in the commit e3e3400.
+    $contentcopiedrecord = $DB->get_record($table, ['stringid' => 'contentCopied']);
+    $contentcopiedrecord->stringid = 'contentcopied';
+    $DB->update_record($table, $contentcopiedrecord);
+}
+
+/**
  * Hvp module upgrade function.
  *
  * @param string $oldversion The version we are upgrading from
@@ -501,7 +529,8 @@ function xmldb_hvp_upgrade($oldversion) {
         2017060900,
         2018090300,
         2019022600,
-        2019030700
+        2019030700,
+        2020042200,
     ];
 
     foreach ($upgrades as $version) {

--- a/version.php
+++ b/version.php
@@ -23,9 +23,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020020500;
+$plugin->version   = 2020042200;
 $plugin->requires  = 2013051403;
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '1.20.2';
+$plugin->release   = '1.20.3';


### PR DESCRIPTION
Hi,

Can anyone review this and merge?

Issue: Throwing dmlwriteexception error in language customisation settings due to the language strings having uppercase.

Fix: Updated the records of uppercase language strings with lowercase in the table tool_customlang. Only below strings have upper case issues.

    reuseContent
    reuseDescription
    contentCopied

Please review and let me know if there are any issues.

Thanks,
Anu