### PR TITLE
Issue: #350 Support alternate file storage class

### DIFF
--- a/classes/framework.php
+++ b/classes/framework.php
@@ -55,7 +55,14 @@ class framework implements \H5PFrameworkInterface {
         if (!isset($interface)) {
             $interface = new \mod_hvp\framework();
 
-            $fs = new \mod_hvp\file_storage();
+            // Support alternate file storage class defined in $CFG
+            if (!empty($CFG->mod_hvp_file_storage_class)) {
+                $fsclass = $CFG->mod_hvp_file_storage_class;
+            } else {
+                $fsclass = '\mod_hvp\file_storage';
+            }
+
+            $fs = new $fsclass();
 
             $context = \context_system::instance();
             $root = view_assets::getsiteroot();


### PR DESCRIPTION
This PR allows us to solve #350 in our own way without modifying any code in the h5p plugin.

In our case we will be adding some MUC caching support for Library files.
Other Moodle Partners may decide to do it in a different way.

I think this is the best solution to the problem.