### PR TITLE
Issue #359: Fixed field NOTNULL in upgrade script

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -495,6 +495,18 @@ function hvp_upgrade_2020080400() {
     }
 }
 
+function hvp_upgrade_2020080401() {
+    global $DB;
+    $dbman = $DB->get_manager();
+
+    // Changing nullability of field completionpass on table hvp to not null.
+    $table = new xmldb_table('hvp');
+    $field = new xmldb_field('completionpass', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '0', 'timemodified');
+
+    // Launch change of nullability for field completionpass.
+    $dbman->change_field_notnull($table, $field);
+}
+
 /**
  * Hvp module upgrade function.
  *
@@ -517,6 +529,7 @@ function xmldb_hvp_upgrade($oldversion) {
         2019022600,
         2019030700,
         2020080400,
+        2020080401,
     ];
 
     foreach ($upgrades as $version) {

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020080400;
+$plugin->version   = 2020080401;
 $plugin->requires  = 2013051403;
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';


### PR DESCRIPTION
Closes #359.
This must be done as a new version bump to retroactively fix any broken DBs, so I microbumped the plugin version.