### PR TITLE
Add index to hvp_content_user_data

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -75,6 +75,9 @@
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
       </KEYS>
+      <INDEXES>
+        <INDEX NAME="userdata" UNIQUE="false" FIELDS="user_id, hvp_id, sub_content_id, data_id"/>
+      </INDEXES>
     </TABLE>
     <TABLE NAME="hvp_libraries" COMMENT="Stores information about libraries.">
       <FIELDS>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -565,6 +565,21 @@ function hvp_upgrade_2020112600() {
     }
 }
 
+function hvp_upgrade_2022012001() {
+    global $DB;
+    $dbman = $DB->get_manager();
+
+    $table = new xmldb_table('hvp_content_user_data');
+
+    // Define index business (not unique) to be added to enrol_paypal.
+    $index = new xmldb_index('userdata', XMLDB_INDEX_NOTUNIQUE, ['user_id', 'hvp_id', 'sub_content_id', 'data_id']);
+
+    // Conditionally launch add index business.
+    if (!$dbman->index_exists($table, $index)) {
+        $dbman->add_index($table, $index);
+    }
+}
+
 /**
  * Hvp module upgrade function.
  *
@@ -591,6 +606,7 @@ function xmldb_hvp_upgrade($oldversion) {
         2020082800,
         2020091500,
         2020112600,
+        2022012001,
     ];
 
     foreach ($upgrades as $version) {

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022012000;
+$plugin->version   = 2022012001;
 $plugin->requires  = 2013051403;
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';


### PR DESCRIPTION
Running a site with > 2M rows in this table performance degrades to make the almost unusable, this additional index solves the problem.