### PR TITLE
Issue #460: Locking session while saving large content

### DIFF
--- a/classes/view_assets.php
+++ b/classes/view_assets.php
@@ -99,6 +99,16 @@ class view_assets {
     private function getfilteredparameters() {
         global $PAGE;
 
+        // If storing a file the session must be closed before closing the
+        // file with H5P content because file closure might take
+        // substantial time. This will allow other pages to use the session
+        // without waiting on the file operation to finish.
+        //
+        // NOTE: the method framework::messages() must not be called before
+        //       the session is closed.
+        if (empty($this->content["filtered"]))
+            \core\session\manager::write_close();
+
         $safeparameters = $this->core->filterParameters($this->content);
         $decodedparams  = json_decode($safeparameters);
         $hvpoutput      = $PAGE->get_renderer('mod_hvp');


### PR DESCRIPTION
The description of the problem and steps to repeat are provided in Issue #460.

Profiling shows that 95% of time is spent inside `h5p.classes.php: H5PExport > createExportFile > $zip->Close()` call:

https://github.com/h5p/h5p-php-library/blob/c84217f8414c06ebabe3dedb046a77c42c2f0dbf/h5p.classes.php#L1931

However, the library submodule is used not only with Moodle. For this reason the patch is proposed for Moodle plugin.

The solution for the session locking would be to write_close() the session before finishing zip file. It will allow other pages to use session without waiting on the file operation to finish.

The main concern is that `framework::messages()` should not be called before the session is closed.
My testing confirms that `framework::messages()` is not called at all when the file content is being saved.
https://github.com/h5p/moodle-mod_hvp/blob/9d9e785160541095488b6184223a16b4697745f2/classes/framework.php#L321-L330

framework::messages() is only called when the content is loaded for viewing or editing. However, in such case the session is not closed (the session will be closed only before the file storing).

The testing method is described in Issue #460. Although the file saving can take considerable time (which is expected for large files), the session is not locked and another page can be opened in a separate tab without giving errors.