### PR TITLE
MBS-7391: Replace the deprecated print_error by moodle exception

### DIFF
--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -47,11 +47,11 @@ class mobile {
         // Verify course context.
         $cm = get_coursemodule_from_id('hvp', $cmid);
         if (!$cm) {
-            print_error('invalidcoursemodule');
+            throw new \moodle_exception('invalidcoursemodule');
         }
         $course = $DB->get_record('course', array('id' => $cm->course));
         if (!$course) {
-            print_error('coursemisconf');
+            throw new \moodle_exception('coursemisconf');
         }
         require_course_login($course, false, $cm, true, true);
         $context = context_module::instance($cm->id);

--- a/classes/view_assets.php
+++ b/classes/view_assets.php
@@ -342,7 +342,7 @@ class view_assets {
      */
     public function validatecontent() {
         if ($this->content === null) {
-            print_error('invalidhvp', 'mod_hvp');
+            throw new \moodle_exception('invalidhvp');
         }
     }
 

--- a/embed.php
+++ b/embed.php
@@ -42,11 +42,11 @@ if (\mod_hvp\mobile_auth::has_valid_token($userid, $secret)) {
 // Verify course context.
 $cm = get_coursemodule_from_id('hvp', $id);
 if (!$cm) {
-    print_error('invalidcoursemodule');
+    throw new \moodle_exception('invalidcoursemodule');
 }
 $course = $DB->get_record('course', array('id' => $cm->course));
 if (!$course) {
-    print_error('coursemisconf');
+    throw new \moodle_exception('coursemisconf');
 }
 
 try {

--- a/grade.php
+++ b/grade.php
@@ -30,10 +30,10 @@ $id = required_param('id', PARAM_INT);
 $userid = optional_param('userid', 0, PARAM_INT);
 
 if (! $cm = get_coursemodule_from_id('hvp', $id)) {
-    print_error('invalidcoursemodule');
+    throw new \moodle_exception('invalidcoursemodule');
 }
 if (! $course = $DB->get_record('course', array('id' => $cm->course))) {
-    print_error('coursemisconf');
+    throw new \moodle_exception('coursemisconf');
 }
 require_course_login($course, false, $cm);
 
@@ -53,7 +53,7 @@ $hvp = $DB->get_record_sql(
         array($cm->instance));
 
 if ($hvp === false) {
-    print_error('invalidhvp', 'mod_hvp');
+    throw new \moodle_exception('invalidhvp');
 }
 
 // Redirect to report if a specific user is chosen.

--- a/index.php
+++ b/index.php
@@ -33,7 +33,7 @@ $PAGE->set_url($url);
 // Load Course.
 $course = $DB->get_record('course', array('id' => $id));
 if (!$course) {
-    print_error('invalidcourseid');
+    throw new \moodle_exception('invalidcourseid');
 }
 
 // Require login.

--- a/review.php
+++ b/review.php
@@ -29,10 +29,10 @@ $id     = required_param('id', PARAM_INT);
 $userid = optional_param('user', (int) $USER->id, PARAM_INT);
 
 if (!$cm = get_coursemodule_from_instance('hvp', $id)) {
-    print_error('invalidcoursemodule');
+    throw new \moodle_exception('invalidcoursemodule');
 }
 if (!$course = $DB->get_record('course', ['id' => $cm->course])) {
-    print_error('coursemisconf');
+    throw new \moodle_exception('coursemisconf');
 }
 require_login($course, false, $cm);
 
@@ -53,7 +53,7 @@ $hvp = $DB->get_record_sql(
     [$id]);
 
 if ($hvp === false) {
-    print_error('invalidhvp', 'mod_hvp');
+    throw new \moodle_exception('invalidhvp');
 }
 
 // Set page properties.

--- a/share.php
+++ b/share.php
@@ -30,11 +30,11 @@ $id = required_param('id', PARAM_INT);
 // Verify course context.
 $cm = get_coursemodule_from_id('hvp', $id);
 if (!$cm) {
-    print_error('invalidcoursemodule');
+    throw new \moodle_exception('invalidcoursemodule');
 }
 $course = $DB->get_record('course', array('id' => $cm->course));
 if (!$course) {
-    print_error('coursemisconf');
+    throw new \moodle_exception('coursemisconf');
 }
 require_course_login($course, true, $cm);
 $context = context_module::instance($cm->id);
@@ -43,7 +43,7 @@ require_capability('mod/hvp:share', $context);
 // Check if Hub registered, if not redirect to hub registration.
 if (empty(get_config('mod_hvp', 'site_uuid')) || empty(get_config('mod_hvp', 'hub_secret'))) {
     if (!has_capability('mod/hvp:contenthubregistration', \context_system::instance())) {
-        print_error('nohubregistration', 'mod_hvp');
+        throw new \moodle_exception('nohubregistration');
     }
     redirect(new moodle_url('/mod/hvp/content_hub_registration.php'));
 }
@@ -60,10 +60,10 @@ if ($action) {
     }
     $token = required_param('_token', PARAM_RAW);
     if (!\H5PCore::validToken('share_' . $id, $token)) {
-        print_error('invalidtoken', 'mod_hvp');
+        throw new \moodle_exception('invalidtoken');
     }
     if (empty($content['contentHubId']) || $content['shared'] !== '1') {
-        print_error('contentnotshared', 'mod_hvp');
+        throw new \moodle_exception('contentnotshared');
     }
 
     $core = \mod_hvp\framework::instance();

--- a/view.php
+++ b/view.php
@@ -30,11 +30,11 @@ $id = required_param('id', PARAM_INT);
 // Verify course context.
 $cm = get_coursemodule_from_id('hvp', $id);
 if (!$cm) {
-    print_error('invalidcoursemodule');
+    throw new \moodle_exception('invalidcoursemodule');
 }
 $course = $DB->get_record('course', array('id' => $cm->course));
 if (!$course) {
-    print_error('coursemisconf');
+    throw new \moodle_exception('coursemisconf');
 }
 require_course_login($course, true, $cm);
 $context = context_module::instance($cm->id);


### PR DESCRIPTION
Print error is deprecated from moodle 4.1. It should be replaced by threw new moodle exception