### PR TITLE
Adding resizer backup and restore step

### DIFF
--- a/backup/moodle2/backup_hvp_activity_task.class.php
+++ b/backup/moodle2/backup_hvp_activity_task.class.php
@@ -85,6 +85,10 @@ class backup_hvp_activity_task extends backup_activity_task {
         $search = "/(".$base."\/mod\/hvp\/embed.php\?id\=)([0-9]+)/";
         $content = preg_replace($search, '$@HVPEMBEDBYID*$2@$', $content);
 
+        // Link to hvp resizer script
+        $search = "/(".$base."\/mod\/hvp\/library\/js\/h5p-resizer.js)/";
+        $content = preg_replace($search,'$@HVPRESIZER@$', $content);
+
         return $content;
     }
 }

--- a/backup/moodle2/restore_decode_rule_h5p_url.class.php
+++ b/backup/moodle2/restore_decode_rule_h5p_url.class.php
@@ -1,0 +1,19 @@
+<?php
+class restore_decode_rule_h5p_url extends restore_decode_rule {
+
+    /**
+     * This class exists so that restore can run over URLs to H5P Scripts which
+     * do not have an id referencing the course / course module - their soley static
+     * scripts used across the activity - e.g. h5p-resizer.js - this is included when
+     * embedding a h5p activity, but not specific to an activity - the url still needs
+     * to be replaced with one relevant to the new restore site.
+     *
+     * @param $linkname
+     * @param $urltemplate
+     * @param $mappings
+     * @return array
+     */
+    protected function validate_params($linkname, $urltemplate, $mappings) {
+        return [];
+    }
+}

--- a/backup/moodle2/restore_hvp_activity_task.class.php
+++ b/backup/moodle2/restore_hvp_activity_task.class.php
@@ -25,7 +25,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+global $CFG;
 require_once($CFG->dirroot . '/mod/hvp/backup/moodle2/restore_hvp_stepslib.php'); // Because it exists (must).
+require_once($CFG->dirroot . '/mod/hvp/backup/moodle2/restore_decode_rule_h5p_url.class.php');
 
 /**
  * Hvp restore task that provides all the settings and steps to perform one complete restore of the activity.
@@ -75,6 +77,7 @@ class restore_hvp_activity_task extends restore_activity_task {
         $rules[] = new restore_decode_rule('HVPVIEWBYID', '/mod/hvp/view.php?id=$1', 'course_module');
         $rules[] = new restore_decode_rule('HVPINDEX', '/mod/hvp/index.php?id=$1', 'course');
         $rules[] = new restore_decode_rule('HVPEMBEDBYID', '/mod/hvp/embed.php?id=$1', 'course_module');
+        $rules[] = new restore_decode_rule_h5p_url('HVPRESIZER', '/mod/hvp/library/js/h5p-resizer.js', []);
 
         return $rules;
     }


### PR DESCRIPTION
Added an extra step to handle the backup and restore of embedded h5p activities to replace the domain linked to the h5p-resizer script

Resolves: #498 