### PR TITLE
Fix error caused by loading assets in completion pages

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -116,12 +116,18 @@ function hvp_get_core_assets($context) {
     // Add core stylesheets.
     foreach (\H5PCore::$styles as $style) {
         $settings['core']['styles'][] = $relpath . $style . $cachebuster;
-        $PAGE->requires->css(new moodle_url($liburl . $style . $cachebuster));
+        // Only add stylesheets to page if not on a completion page.
+        if (!\hvp_check_completion_pages($PAGE->pagetype)) {
+            $PAGE->requires->css(new moodle_url($liburl . $style . $cachebuster));
+        }
     }
     // Add core JavaScript.
     foreach (\H5PCore::$scripts as $script) {
         $settings['core']['scripts'][] = $relpath . $script . $cachebuster;
-        $PAGE->requires->js(new moodle_url($liburl . $script . $cachebuster), true);
+        // Only add scripts to page if not on a completion page.
+        if (!\hvp_check_completion_pages($PAGE->pagetype)) {
+            $PAGE->requires->js(new moodle_url($liburl . $script . $cachebuster), true);
+        }
     }
 
     return $settings;
@@ -719,4 +725,21 @@ function hvp_create_hub_export_url($cmid, $content) {
  */
 function hvp_base64_encode($string) {
     return str_replace('=', '', strtr(base64_encode($string), '+/', '-_'));
+}
+
+/**
+ * Check if the given page type is a completion page.
+ * Use this function to avoid loading H5P assets on completion pages.
+ *
+ * @param string $pageType
+ * @return bool
+ */
+function hvp_check_completion_pages($pageType) {
+    $completionpagetypes = [
+        'course-defaultcompletion' => 'Edit completion default settings (Moodle >= 4.3)',
+        'course-editbulkcompletion' => 'Edit completion settings in bulk for a single course',
+        'course-editdefaultcompletion' => 'Edit completion default settings (Moodle < 4.3)',
+    ];
+
+    return array_key_exists($pageType, $completionpagetypes);
 }


### PR DESCRIPTION
This PR will fix the following warning at the course default completion page.
e.g. https://moodlesite/course/defaultcompletion.php?id=1

data_preprocessing function of module hvp should be fixed so it can be shown together with other Default activity completion forms
line 138 of /completion/classes/defaultedit_form.php: call to debugging()
line 217 of /lib/formslib.php: call to core_completion_defaultedit_form->definition()
line 45 of /completion/classes/defaultedit_form.php: call to moodleform->__construct()
line 89 of /course/classes/output/bulk_activity_completion_renderer.php: call to core_completion_defaultedit_form->__construct()
line 97 of /course/defaultcompletion.php: call to core_course_bulk_activity_completion_renderer->defaultcompletion()