### PR TITLE
fix for warning: Attempt to read property "id" on bool

### DIFF
--- a/classes/framework.php
+++ b/classes/framework.php
@@ -1513,8 +1513,8 @@ class framework implements \H5PFrameworkInterface {
             'minor_version' => $minorversion
         ));
 
-        if (!$library) {
-            return false;
+        if (empty($library) || !isset($library->id)) {
+            return [];
         }
 
         $librarydata = array(


### PR DESCRIPTION
This PR fixes #578
For more info https://github.com/h5p/moodle-mod_hvp/issues/578#issue-2830395439

This only returns empty array when the library does not exists, and in case of new installation it would then proceeds with fresh installation!