### PR TITLE
#539 The deprecated function get_all_user_name fields should be replaced if possible

### DIFF
--- a/classes/results.php
+++ b/classes/results.php
@@ -295,7 +295,12 @@ class results {
         static $ordered;
 
         if (empty($ordered)) {
-            $available = \get_all_user_name_fields();
+            if (class_exists('\core_user\fields')) {
+                $available = \core_user\fields::get_name_fields();
+            } else {
+                $available = \get_all_user_name_fields();
+            }
+
             $displayname = \fullname((object)$available);
             if (empty($displayname)) {
                 $ordered = array("{$prefix}firstname", "{$prefix}lastname");

--- a/locallib.php
+++ b/locallib.php
@@ -577,7 +577,11 @@ function hvp_send_notification_messages($course, $hvp, $attempt, $context, $cm) 
     // Check for notifications required.
     $notifyfields = 'u.id, u.username, u.idnumber, u.email, u.emailstop, u.lang,
             u.timezone, u.mailformat, u.maildisplay, u.auth, u.suspended, u.deleted, ';
-    $notifyfields .= get_all_user_name_fields(true, 'u');
+    if (class_exists('\core_user\fields')) {
+        $notifyfields .= \core_user\fields::for_name()->get_sql('u', false, '', '', false)->selects;
+    } else {
+        $notifyfields .= get_all_user_name_fields(true, 'u');
+    }
     $groups       = groups_get_all_groups($course->id, $submitter->id, $cm->groupingid);
     if (is_array($groups) && count($groups) > 0) {
         $groups = array_keys($groups);


### PR DESCRIPTION
The `\core_user\fields` API should be applied if possible.