### PR TITLE
Optimize file annotation in backup process for significant speed improvement

### DIFF
--- a/backup/moodle2/backup_hvp_stepslib.php
+++ b/backup/moodle2/backup_hvp_stepslib.php
@@ -240,7 +240,7 @@ class backup_hvp_libraries_structure_step extends backup_structure_step {
 
         // Define file annotations.
         $context = \context_system::instance();
-        $library->annotate_files('mod_hvp', 'libraries', null, $context->id);
+        $libraries->annotate_files('mod_hvp', 'libraries', null, $context->id);
 
         // Return root element.
         return $libraries;


### PR DESCRIPTION
## Info
We are excited to present this one-liner patch that significantly improves the runtime (up to 100x faster). Our team has conducted extensive research and testing as part of a client project. We hope this enhancement helps you with the previously slow backups in your Moodle installations. If you have any questions, you can reach us through our website: [Sudile GbR](https://www.sudile.com/home-eng/).

The exact impacts of this change are described below.

####  Solution
https://github.com/h5p/moodle-mod_hvp/blob/stable/backup/moodle2/backup_hvp_stepslib.php#L243
The line at this location needs to be:
```php
$libraries->annotate_files('mod_hvp', 'libraries', null, $context->id);
```

#### Explanation
All the library files exist in the context system and therefore have no context difference. If added to the child element `$library`, Moodle tries to add all module files into the library node. This leads to a situation where, for each library, all the files are being loaded. Only at the very end does Moodle resolve the issue by saving the files in the archive, which only allows unique files by hash.

#### Related issues
https://github.com/h5p/moodle-mod_hvp/issues/423 https://github.com/h5p/moodle-mod_hvp/issues/262 https://github.com/h5p/moodle-mod_hvp/issues/253 https://github.com/h5p/moodle-mod_hvp/issues/423 https://github.com/h5p/moodle-mod_hvp/issues/561

Vincent Schneider (vincent.schneider@sudile.com)