### PR TITLE
#532 Ensure that the pass grade is formated as a numerical value

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -327,6 +327,12 @@ class mod_hvp_mod_form extends moodleform_mod {
             $errors['maximumgrade'] = get_string('maximumgradeerror', 'hvp');
         }
 
+        // Ensure that the pass grade is formatted as a numerical value.
+        $data['gradepass'] = unformat_float($data['gradepass'], true);
+        if ($data['gradepass'] === false) {
+            $errors['gradepass'] = get_string('err_numeric', 'core_form');
+        }
+
         if ($data['h5paction'] === 'upload') {
             // Validate uploaded H5P file.
             unset($errors['name']); // Will be set in data_postprocessing().


### PR DESCRIPTION
Because if the "gradepass" field is frozen, the value interpreted in another language will not be validated or formatted. Before the "gradepass" value is used in H5P's instance form validation, this value should be formatted.