### PR TITLE
fix/AU-7820 Fix clearing parameters recursively for content dependencies

### DIFF
--- a/classes/framework.php
+++ b/classes/framework.php
@@ -1570,8 +1570,12 @@ class framework implements \H5PFrameworkInterface {
         $DB->execute("
             UPDATE {hvp}
             SET filtered = null
-            WHERE main_library_id $insql",
-            $inparams
+            WHERE id IN (
+                SELECT DISTINCT cl.hvp_id
+                FROM {hvp_contents_libraries} cl
+                WHERE library_id $insql
+            )",
+          $inparams
         );
     }
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -567,6 +567,14 @@ function hvp_upgrade_2020112600() {
     }
 }
 
+function hvp_upgrade_2026050600() {
+  global $DB;
+  $DB->execute("
+    UPDATE {hvp}
+    SET filtered = NULL
+  ");
+}
+
 /**
  * Hvp module upgrade function.
  *
@@ -593,6 +601,7 @@ function xmldb_hvp_upgrade($oldversion) {
         2020082800,
         2020091500,
         2020112600,
+        2026050600,
     ];
 
     foreach ($upgrades as $version) {

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026031900;
+$plugin->version   = 2026050600;
 $plugin->requires  = 2013051403;
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';


### PR DESCRIPTION
We are changing the functionality of clearing parameters when updating
a library to run for all content that has a dependency to the version
being uploaded, to avoid missing libraries in compound content types.
As part of this we are also clearing all filtered parameters, to fix
content that may be already missing dependencies in the wild.
