### PR TITLE
Fixes #597 - circumvents calling json_decode() with null

### DIFF
--- a/classes/editor_framework.php
+++ b/classes/editor_framework.php
@@ -138,7 +138,8 @@ class editor_framework implements \H5peditorStorage {
                     $library->title = $details->title;
                     $library->runnable = $details->runnable;
                     $library->restricted = $superuser ? false : ($details->restricted === '1' ? true : false);
-                    $library->metadataSettings = json_decode($details->metadata_settings);
+                    $library->metadataSettings =
+                        is_string($details->metadata_settings) ? json_decode($details->metadata_settings) : null;
                     $librarieswithdetails[] = $library;
                 }
             }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixes #597.
The database field is either null or a string. So decode strings and else set null.

**What is the current behaviour?**
See #597.

**What is the new behaviour?**
Calling json_decode() with null is circumvented. No PHP error log entry is logged.

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.
