### PR TITLE
Add extraTableClasses to work with Bootstrap 5, closes https://github.com/h5p/h5p-php-library/issues/272

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -261,6 +261,7 @@ function hvp_admin_add_generic_css_and_js($page, $liburl, $settings = null) {
         'deleteLibrary' => '',
         'upgradeLibrary' => get_string('upgradelibrarycontent', 'hvp')
     );
+    $settings['extraTableClasses'] = 'table-reboot';
 
     $page->requires->data_for_js('H5PAdminIntegration', $settings, true);
     $page->requires->css(new moodle_url($liburl . 'styles/h5p.css' . hvp_get_cache_buster()));


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix

**What is the current behaviour?**
Reported in and closes https://github.com/h5p/h5p-php-library/issues/272 (wrong repo):
Due to the migration to Bootstrap 5 in recent Moodle versions, the table for the library settings page now shows borders that were not there previously.
<img width="922" height="293" alt="image" src="https://github.com/user-attachments/assets/1d124a50-fff2-47d6-a15d-6b4337b9bfc0" />

**What is the new behaviour?**
The table does not show borders.
<img width="922" height="293" alt="image" src="https://github.com/user-attachments/assets/214486e7-f93c-4a72-9c3e-7528314cc978" />

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.
