### PR TITLE
fix: Add back semantics prop to library upgrade response

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -427,7 +427,8 @@ function hvp_get_library_upgrade_info($name, $major, $minor) {
         $basepath = \mod_hvp\view_assets::getsiteroot() . '/';
         $response->upgradesScript = "{$basepath}pluginfile.php/{$context->id}/mod_hvp/libraries/{$libraryfoldername}/upgrades.js";
     }
-
+    $response->semantics = $core->loadLibrarySemantics($name, $major, $minor);
+    
     return $response;
 }
 


### PR DESCRIPTION
Thank you for your interest in contributing to H5P! 🎉  
Please fill in the below sections to make your pull request:

**What kind of change does this PR introduce?**
Bug fix

**What is the current behaviour?**
Content parameters will not be upgraded when running batch upgrades. Was caused by https://github.com/h5p/moodle-mod_hvp/commit/d16c4c030d1f1ac732c0964c85a2d2de137b57d1#diff-3494b45596f0f648d894a5f22070eaae01f3e0ea664be0430b8d23eb7d93e35aL423

Compare report at https://github.com/h5p/moodle-mod_hvp/issues/632

**What is the new behaviour?**
Content parameters will be upgraded when running batch upgrades.

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.
