### PR TITLE
fix: Replace deprecated use of $cm->extra

### DIFF
--- a/index.php
+++ b/index.php
@@ -88,8 +88,8 @@ if (empty($modinfo->instances['hvp'])) {
         if (!$cm->uservisible || !isset($rawh5ps[$cm->id])) {
             continue; // Not visible or not found.
         }
-        if (!empty($cm->extra)) {
-            $rawh5ps[$cm->id]->extra = $cm->extra;
+        if (!empty($cm->extraclasses)) {
+            $rawh5ps[$cm->id]->extra = $cm->extraclasses;
         }
         $h5ps[] = $rawh5ps[$cm->id];
     }

--- a/index.php
+++ b/index.php
@@ -88,9 +88,6 @@ if (empty($modinfo->instances['hvp'])) {
         if (!$cm->uservisible || !isset($rawh5ps[$cm->id])) {
             continue; // Not visible or not found.
         }
-        if (!empty($cm->extraclasses)) {
-            $rawh5ps[$cm->id]->extra = $cm->extraclasses;
-        }
         $h5ps[] = $rawh5ps[$cm->id];
     }
 }


### PR DESCRIPTION
See MDL-25981 (https://moodle.atlassian.net/browse/MDL-25981)

Thank you for your interest in contributing to H5P! 🎉  
Please fill in the below sections to make your pull request:

**What kind of change does this PR introduce?**
Bug fix

**What is the current behaviour?**
See https://github.com/h5p/moodle-mod_hvp/issues/634

When viewing the "H5P overview" page, you yield:
```
Deprecation: core_course\cm_info::extra has been deprecated since 2.0. This is crazy, don't use it.. Use ->extraclasses and ->onclick instead. See MDL-25981 for more information.
line 276 of /public/lib/classes/deprecation.php: call to debugging()
line 136 of /public/lib/classes/deprecation.php: call to core\deprecation::emit_deprecation_notice()
line 698 of /public/course/classes/cm_info.php: call to core\deprecation::emit_deprecation_if_present()
line 91 of /public/mod/hvp/index.php: call to core_course\cm_info->__isset()
```
in the browser, not just the error log.

The H5P plugin is using an approach that had been declared deprecated even before the H5P plugin was created!? It now triggers a visible message.

**What is the new behaviour?**
Accessing the class names was changed following [MDL-25981](https://moodle.atlassian.net/browse/MDL-25981). Error message disappears.

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.

Closes https://github.com/h5p/moodle-mod_hvp/issues/634