### PR TITLE
fix / Remove deprecated FEATURE_GROUPMEMBERSONLY from hvp_supports()

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -52,8 +52,6 @@ function hvp_supports($feature) {
             return true;
         case FEATURE_GROUPINGS:
             return true;
-        case FEATURE_GROUPMEMBERSONLY:
-            return true;
         case FEATURE_MOD_INTRO:
             return true;
         case FEATURE_COMPLETION_TRACKS_VIEWS:


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix (removal of a deprecated Moodle constant).

**What is the current behaviour?**
`hvp_supports()` in `lib.php` lists `FEATURE_GROUPMEMBERSONLY` as a supported feature. That constant was deprecated in Moodle 2.9 ([MDL-44725](https://moodle.atlassian.net/browse/MDL-44725)) when the "group members only" access control was superseded by the availability system ([MDL-44070](https://moodle.atlassian.net/browse/MDL-44070)), and it is being removed from core entirely ([MDL-83231](https://moodle.atlassian.net/browse/MDL-83231)). On Moodle 5.3+ the removed constant makes the `case` reference an undefined constant, which fatals and blocks the plugin from upgrading. Reported in #636.

**What is the new behaviour?**
The `case FEATURE_GROUPMEMBERSONLY: return true;` arm is removed from `hvp_supports()`. One file, two lines. Core stopped querying activity modules for this feature in 2.9, so no supported Moodle version calls `hvp_supports(FEATURE_GROUPMEMBERSONLY)`; dropping the case changes no runtime behaviour on older releases while clearing the fatal on 5.3+. There is no group-members-only logic in the plugin to migrate to the availability system: `hvp_supports()` only advertises capabilities, and the `default: return null;` arm continues to handle any unknown feature. `php -l lib.php` passes. No unit test is added: this is a pure capability-advertisement removal with no meaningful regression assertion available (a test would only exercise the generic `default` arm), matching recent deprecation fixes here (#626, #631) that merged without tests.

## PR Checklist

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [ ] I tested my changes locally <!-- php -l passes; not run on a live Moodle 5.3 instance -->

closes #636

---

AI assistance (Claude) was used to analyse the deprecation and draft this change; I reviewed it against the Moodle tracker issues and the plugin source, and take responsibility for it.
