### PR TITLE
fix / inform about update failure / success

### DIFF
--- a/classes/task/look_for_updates.php
+++ b/classes/task/look_for_updates.php
@@ -23,6 +23,8 @@
 
 namespace mod_hvp\task;
 
+use invalid_response_exception;
+
 defined('MOODLE_INTERNAL') || die();
 
 /**
@@ -41,7 +43,24 @@ class look_for_updates extends \core\task\scheduled_task {
         // Check to make sure external communications hasn't been disabled.
         if (get_config('mod_hvp', 'hub_is_enabled') || get_config('mod_hvp', 'send_usage_statistics')) {
             $core = \mod_hvp\framework::instance();
-            $core->fetchLibrariesMetadata();
+            $result = $core->fetchLibrariesMetadata();
+
+            if ($result === false) {
+                throw new invalid_response_exception('Could not fetch libraries\' metadata from the H5P Hub');
+            }
+
+            $json = json_decode($result, true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new invalid_response_exception('Received malformed response from the H5P Hub');
+            }
+
+            $contenttypes = $json['contentTypes'] ?? null;
+            if (!is_array($contenttypes)) {
+                throw new invalid_response_exception('Received malformed response from the H5P Hub: No contentTypes property found');
+            }
+
+            $numberentries = count($contenttypes);
+            mtrace("{$numberentries} entries for content type libraries fetched");
         }
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix

**What is the current behaviour?**
Task that updates the metadata cache fails silently (see https://github.com/h5p/moodle-mod_hvp/issues/638)

**What is the new behaviour?**
Task follows Moodle's [Task API](https://moodledev.io/docs/5.2/apis/subsystems/task) guidelines:
- Throws exception when metadata could not be fetched properly.
- Throws exception when metadata is malformed.
- Follows good practice and logs informative message (number of entries for content type libraries fetched).

Fixes https://github.com/h5p/moodle-mod_hvp/issues/638

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.
