### PR TITLE
MBS-10983: fix / Make look_for_updates task handle errors properly

### DIFF
--- a/classes/task/look_for_updates.php
+++ b/classes/task/look_for_updates.php
@@ -13,20 +13,11 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-/**
- * Defines the task which looks for H5P updates.
- *
- * @package    mod_hvp
- * @copyright  2016 Joubel AS <contact@joubel.com>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
 
 namespace mod_hvp\task;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
- * The mod_hvp look for updates task class
+ * Defines the task which looks for H5P updates.
  *
  * @package    mod_hvp
  * @copyright  2016 Joubel AS <contact@joubel.com>
@@ -38,10 +29,44 @@ class look_for_updates extends \core\task\scheduled_task {
     }
 
     public function execute() {
-        // Check to make sure external communications hasn't been disabled.
-        if (get_config('mod_hvp', 'hub_is_enabled') || get_config('mod_hvp', 'send_usage_statistics')) {
-            $core = \mod_hvp\framework::instance();
-            $core->fetchLibrariesMetadata();
+        // Check to make sure external communications have not been disabled.
+        if (!get_config('mod_hvp', 'hub_is_enabled') && !get_config('mod_hvp', 'send_usage_statistics')) {
+            mtrace(get_string('lookforupdatesskippeddisabledlog', 'mod_hvp'));
+            return;
+        }
+
+        $core = \mod_hvp\framework::instance();
+        $result = $core->fetchLibrariesMetadata();
+
+        if ($result === false) {
+            mtrace(get_string('fetchlibrariesmetadatafailedlog', 'mod_hvp'));
+        } else if (is_object($result)) {
+            $librariescount = 0;
+            if (isset($result->libraries) && is_array($result->libraries)) {
+                $librariescount = count($result->libraries);
+            }
+            mtrace(get_string('fetchlibrariesmetadatasuccesslog', 'mod_hvp', $librariescount));
+        } else {
+            mtrace(get_string('fetchlibrariesmetadataunexpectedlog', 'mod_hvp'));
+        }
+
+        $errors = \mod_hvp\framework::messages('error');
+        foreach ($errors as $error) {
+            $code = $error->code ?? 'N/A';
+            $text = $error->message ?? 'N/A';
+            mtrace(get_string('fetchlibrariesmetadataerrorlog', 'mod_hvp', (object) [
+                'code' => $code,
+                'message' => $text,
+            ]));
+        }
+
+        $infos = \mod_hvp\framework::messages('info');
+        foreach ($infos as $info) {
+            mtrace(get_string('fetchlibrariesmetadatainfolog', 'mod_hvp', $info));
+        }
+
+        if ($result === false) {
+            throw new \moodle_exception('fetchlibrariesmetadatafailed', 'mod_hvp');
         }
     }
 }

--- a/lang/en/hvp.php
+++ b/lang/en/hvp.php
@@ -58,6 +58,13 @@ $string['confirmlabel'] = 'Confirm';
 $string['noh5ps'] = 'There\'s no interactive content available for this course.';
 
 $string['lookforupdates'] = 'Look for H5P updates';
+$string['fetchlibrariesmetadatafailed'] = 'Failed to fetch H5P libraries metadata.';
+$string['fetchlibrariesmetadatafailedlog'] = 'Fetching H5P content types from the Hub failed.';
+$string['fetchlibrariesmetadatasuccesslog'] = 'H5P Hub request completed successfully ({$a} content types in the response).';
+$string['fetchlibrariesmetadataunexpectedlog'] = 'H5P Hub request returned an unexpected response.';
+$string['fetchlibrariesmetadataerrorlog'] = 'H5P Hub error: [code: {$a->code}, message: {$a->message}]';
+$string['fetchlibrariesmetadatainfolog'] = 'H5P Hub notice: {$a}';
+$string['lookforupdatesskippeddisabledlog'] = 'Task skipped: both H5P Hub and usage statistics are disabled.';
 $string['updatelibraries'] = 'Update All Libraries';
 $string['removetmpfiles'] = 'Remove old H5P temporary files';
 $string['removeoldlogentries'] = 'Remove old H5P log entries';

--- a/lib.php
+++ b/lib.php
@@ -52,8 +52,6 @@ function hvp_supports($feature) {
             return true;
         case FEATURE_GROUPINGS:
             return true;
-        case FEATURE_GROUPMEMBERSONLY:
-            return true;
         case FEATURE_MOD_INTRO:
             return true;
         case FEATURE_COMPLETION_TRACKS_VIEWS:

--- a/tests/look_for_updates_test.php
+++ b/tests/look_for_updates_test.php
@@ -1,0 +1,110 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_hvp;
+
+/**
+ * Unit tests for look_for_updates scheduled task.
+ *
+ * @package    mod_hvp
+ * @copyright  2026
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \mod_hvp\task\look_for_updates
+ */
+final class look_for_updates_test extends \advanced_testcase {
+    /**
+     * Verifies
+     * - that the task exits early exactly when both hub_is_enabled and send_usage_statistics_setting are disabled
+     * - that the task does proper error handling and logging
+     *
+     * @dataProvider execute_provider
+     * @param int $hubisenabled Hub setting value.
+     * @param int $sendusagestatistics Usage statistics setting value.
+     * @param bool $expectearlyexit Whether execute() is expected to return via early-exit.
+     */
+    public function test_execute(
+        int $hubisenabled,
+        int $sendusagestatistics,
+        bool $expectearlyexit,
+    ): void {
+        $this->resetAfterTest();
+
+        set_config('hub_is_enabled', $hubisenabled, 'mod_hvp');
+        set_config('send_usage_statistics', $sendusagestatistics, 'mod_hvp');
+        // Keep site unregistered so all non-early-exit paths fail deterministically at registration.
+        set_config('site_uuid', '', 'mod_hvp');
+
+        if ($hubisenabled || $sendusagestatistics) {
+            // Force deterministic no-network behavior for all non-early-exit cases.
+            \curl::mock_response('');
+        }
+
+        $task = new \mod_hvp\task\look_for_updates();
+
+        ob_start();
+        try {
+            $task->execute();
+            $output = ob_get_clean();
+            if (!$expectearlyexit) {
+                $this->fail('Expected moodle_exception for failed metadata fetch. Output: ' . $output);
+            }
+        } catch (\moodle_exception $exception) {
+            $output = ob_get_clean();
+            if ($expectearlyexit) {
+                $this->fail('Did not expect moodle_exception. Got: ' . $exception->errorcode);
+            }
+            $this->assertEquals('fetchlibrariesmetadatafailed', $exception->errorcode);
+        }
+
+        if ($expectearlyexit) {
+            $this->assertStringContainsString(get_string('lookforupdatesskippeddisabledlog', 'mod_hvp'), $output);
+        } else {
+            $this->assertStringContainsString(get_string('fetchlibrariesmetadatafailedlog', 'mod_hvp'), $output);
+            $this->assertStringContainsString('registration-failed-hub-disabled', $output);
+            $this->assertStringNotContainsString(get_string('lookforupdatesskippeddisabledlog', 'mod_hvp'), $output);
+        }
+    }
+
+    /**
+     * Data provider for test_execute_setting_combinations.
+     *
+     * @return array
+     */
+    public static function execute_provider(): array {
+        return [
+            'both_disabled' => [
+                'hubisenabled' => 0,
+                'sendusagestatistics' => 0,
+                'expectearlyexit' => true,
+            ],
+            'hub_enabled_only' => [
+                'hubisenabled' => 1,
+                'sendusagestatistics' => 0,
+                'expectearlyexit' => false,
+            ],
+            'usage_statistics_enabled_only' => [
+                'hubisenabled' => 0,
+                'sendusagestatistics' => 1,
+                'expectearlyexit' => false,
+            ],
+            'both_enabled' => [
+                'hubisenabled' => 1,
+                'sendusagestatistics' => 1,
+                'expectearlyexit' => false,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixes #638 

**What is the current behaviour?**
See #638

**What is the new behaviour?**
Proper error handling, task will throw an exception which will be handled by the retry logic, reporting, automatic alerting and everything else that the task API of moodle provides.

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.