### PR TITLE
MBS-11007: Add mod_hvp to activity picker categories

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -66,10 +66,22 @@ function hvp_supports($feature) {
             return true;
         case FEATURE_SHOW_DESCRIPTION:
             return true;
-
+        case FEATURE_MOD_PURPOSE:
+            return MOD_PURPOSE_INTERACTIVECONTENT;
+        case FEATURE_MOD_OTHERPURPOSE:
+            return MOD_PURPOSE_ASSESSMENT;
         default:
             return null;
     }
+}
+
+/**
+ * Whether the H5P activity icon is branded and should not be recoloured by the theme.
+ *
+ * @return bool True because H5P has a protected brand icon.
+ */
+function hvp_is_branded(): bool {
+    return true;
 }
 
 /**


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix/feature

**What is the current behaviour?**
Closes #625 

**What is the new behaviour?**
The mod_hvp activity now can be found in the categories "assessment" and "interactive content" in the moodle activity picker.

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

## Additional context
- I had to implement the function `hvp_is_branded` to avoid that moodle tries to color the icon according to the main category. The icon otherwise would just be a brown square otherwise.
- When choosing the categories I aligned the choice of the categories with the moodle core mod_h5pactivity, so the categories match.
