### PR TITLE
MBS-11015: Cache busting for cached assets

### DIFF
--- a/classes/file_storage.php
+++ b/classes/file_storage.php
@@ -238,6 +238,8 @@ class file_storage implements \H5PFileStorage {
     public function cacheAssets(&$files, $key) {
         $context = \context_system::instance();
         $fs = get_file_storage();
+        $revmanager = \core\di::get(\mod_hvp\local\cached_assets_rev_manager::class);
+        $cachebuster = $revmanager->get_global_cached_assets_buster();
 
         foreach ($files as $type => $assets) {
             if (empty($assets)) {
@@ -285,7 +287,7 @@ class file_storage implements \H5PFileStorage {
             $fs->create_file_from_string($fileinfo, $content);
             $files[$type] = array((object) array(
                 'path' => "/cachedassets/{$key}.{$ext}",
-                'version' => ''
+                'version' => $cachebuster
             ));
         }
     }
@@ -301,6 +303,8 @@ class file_storage implements \H5PFileStorage {
     public function getCachedAssets($key) {
         $context = \context_system::instance();
         $fs = get_file_storage();
+        $revmanager = \core\di::get(\mod_hvp\local\cached_assets_rev_manager::class);
+        $cachebuster = $revmanager->get_global_cached_assets_buster();
 
         $files = array();
 
@@ -308,7 +312,7 @@ class file_storage implements \H5PFileStorage {
         if ($js) {
             $files['scripts'] = array((object) array(
                 'path' => "/cachedassets/{$key}.js",
-                'version' => ''
+                'version' => $cachebuster
             ));
         }
 
@@ -316,7 +320,7 @@ class file_storage implements \H5PFileStorage {
         if ($css) {
             $files['styles'] = array((object) array(
                 'path' => "/cachedassets/{$key}.css",
-                'version' => ''
+                'version' => $cachebuster
             ));
         }
 

--- a/classes/framework.php
+++ b/classes/framework.php
@@ -1663,6 +1663,35 @@ class framework implements \H5PFrameworkInterface {
     }
 
     /**
+     * Delete all cached assets (DB mappings + files) and invalidate the global revision.
+     *
+     * @return string[] array of deleted cached asset hashes
+     */
+    public function deleteAllCachedAssets(): array {
+        global $DB;
+
+        $results = $DB->get_records_sql(
+                'SELECT DISTINCT hash
+                   FROM {hvp_libraries_cachedassets}');
+
+        $hashes = [];
+        foreach ($results as $record) {
+            $hashes[] = $record->hash;
+        }
+
+        $DB->delete_records('hvp_libraries_cachedassets');
+
+        $core = self::instance('core');
+        // There is no interface method for deleting all cached assets, so we pass all existing hashes.
+        $core->fs->deleteCachedAssets($hashes);
+
+        $revmanager = \core\di::get(\mod_hvp\local\cached_assets_rev_manager::class);
+        $revmanager->invalidate_global_cached_assets_rev();
+
+        return $hashes;
+    }
+
+    /**
      * Implements getLibraryStats
      */
     // @codingStandardsIgnoreLine

--- a/classes/framework.php
+++ b/classes/framework.php
@@ -1652,6 +1652,13 @@ class framework implements \H5PFrameworkInterface {
             $DB->delete_records('hvp_libraries_cachedassets', array('hash' => $key->hash));
         }
 
+        // Reset the global cached assets rev. This unfortunately also busts the caches for all other libraries,
+        // which is suboptimal. However, this guarantees that the assets that will be built on demand are in fact
+        // being used by the client browser instead of browser-side cached assets from before in the case that the
+        // cached assets did not change.
+        $revmanager = \core\di::get(\mod_hvp\local\cached_assets_rev_manager::class);
+        $revmanager->invalidate_global_cached_assets_rev();
+
         return $hashes;
     }
 

--- a/classes/local/cached_assets_rev_manager.php
+++ b/classes/local/cached_assets_rev_manager.php
@@ -1,0 +1,69 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_hvp\local;
+
+use core\clock;
+
+/**
+ * Helper to manage the global cached-assets revision.
+ *
+ * @package    mod_hvp
+ * @copyright  2026 ISB Bayern
+ * @author     Philipp Memmel
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class cached_assets_rev_manager {
+    /**
+     * Constructor.
+     */
+    public function __construct(
+        /** @var clock $clock default clock implementation. */
+        private readonly clock $clock
+    ) {
+    }
+
+    /**
+     * Invalidate the global cached-assets revision used for cache busting.
+     */
+    public function invalidate_global_cached_assets_rev(): void {
+        set_config('cachedassetsrev', $this->clock->now()->getTimestamp(), 'mod_hvp');
+    }
+
+    /**
+     * Get the global cached-assets revision used for cache busting.
+     *
+     * @return int
+     */
+    public function get_global_cached_assets_rev(): int {
+        $rev = (int) get_config('mod_hvp', 'cachedassetsrev');
+        if ($rev <= 0) {
+            $this->invalidate_global_cached_assets_rev();
+            $rev = (int) get_config('mod_hvp', 'cachedassetsrev');
+        }
+
+        return $rev;
+    }
+
+    /**
+     * Get query string for cached assets cache busting.
+     *
+     * @return string
+     */
+    public function get_global_cached_assets_buster(): string {
+        return '?rev=' . $this->get_global_cached_assets_rev();
+    }
+}

--- a/lang/en/hvp.php
+++ b/lang/en/hvp.php
@@ -118,6 +118,12 @@ $string['ctcachebuttonlabel'] = 'Update content type cache';
 $string['ctcacheneverupdated'] = 'Never';
 $string['ctcachetaskname'] = 'Update content type cache';
 $string['ctcachedescription'] = 'Making sure the content type cache is up to date will ensure that you can view, download and use the latest libraries. This is different from updating the libraries themselves.';
+$string['clearcachedassetsheader'] = 'Cached Assets';
+$string['clearcachedassetsdescription'] = 'Remove all aggregated cached assets. They will be rebuilt on demand when H5P activities are loaded.';
+$string['clearcachedassetsbuttonlabel'] = 'Clear cached assets';
+$string['clearcachedassetsconfirmtitle'] = 'Clear cached assets';
+$string['clearcachedassetsconfirmbody'] = 'Do you really want to clear all cached assets now?';
+$string['clearcachedassetssuccess'] = 'Cached assets were cleared and will be rebuilt on demand.';
 
 // Upload libraries section.
 $string['uploadlibraries'] = 'Upload Libraries';

--- a/library_list.php
+++ b/library_list.php
@@ -46,6 +46,18 @@ if ($formdata = $uploadform->get_data()) {
 
 $core = \mod_hvp\framework::instance();
 
+if (optional_param('action', '', PARAM_ALPHA) === 'clearcachedassets') {
+    require_sesskey();
+
+    $systemcontext = \context_system::instance();
+    require_capability('mod/hvp:updatelibraries', $systemcontext);
+
+    $core->h5pF->deleteAllCachedAssets();
+
+    \mod_hvp\framework::messages('info', get_string('clearcachedassetssuccess', 'hvp'));
+    redirect($pageurl);
+}
+
 $hubon = $core->h5pF->getOption('hub_is_enabled', true);
 if ($hubon) {
     // Create content type cache form.
@@ -135,6 +147,29 @@ if ($hubon) {
     echo '<h3>' . get_string('contenttypecacheheader', 'hvp') . '</h3>';
     $ctcacheform->display();
 }
+
+$clearcachedassetsurl = new moodle_url('/mod/hvp/library_list.php', array(
+    'action' => 'clearcachedassets',
+    'sesskey' => sesskey(),
+));
+echo html_writer::start_div('row h5p-admin-header');
+echo html_writer::tag('div', get_string('clearcachedassetsheader', 'hvp'), array('class' => 'col-md-3'));
+echo html_writer::start_div('col-md-9');
+echo html_writer::tag('p', get_string('clearcachedassetsdescription', 'hvp'));
+echo html_writer::link($clearcachedassetsurl, get_string('clearcachedassetsbuttonlabel', 'hvp'), array(
+    'class' => 'btn btn-primary',
+    'role' => 'button',
+    'aria-label' => get_string('clearcachedassetsbuttonlabel', 'hvp'),
+    'data-confirmation' => 'modal',
+    'data-confirmation-type' => 'delete',
+    'data-confirmation-title-str' => '["clearcachedassetsconfirmtitle", "hvp"]',
+    'data-confirmation-content-str' => '["clearcachedassetsconfirmbody", "hvp"]',
+    'data-confirmation-yes-button-str' => '["clearcachedassetsbuttonlabel", "hvp"]',
+    'data-confirmation-no-button-str' => '["cancel", "core"]',
+    'data-confirmation-destination' => $clearcachedassetsurl->out(false),
+));
+echo html_writer::end_div();
+echo html_writer::end_div();
 
 // Upload Form.
 echo '<h3 class="h5p-admin-header">' . get_string('uploadlibraries', 'hvp') . '</h3>';


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix/Feature
Fixes #646

**What is the current behaviour?**
See #646 

**What is the new behaviour?**
Whenever a library is updated, the global cached assets revision will be bumped so all cached assets will be fetched again from the moodle instance by client browsers.

Yes, this will lower the effect of the caching that we currently have, but will make sure that the cached assets from the server will be used when necessary.

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

This pull request contains some more or less "modern" features of moodle, so it probably would "only" be downward compatible to moodle 4.4. I'm not sure what the current strategy regarding compatibility is, but moodle 4.4 is not even supported any more, so it might be fine to start breaking with super-old moodle instances.

If there's a different policy, I'm happy to refactor the patch.