### PR TITLE
Option to force enable file extension check, resolves #265.

### DIFF
--- a/classes/upload_libraries_form.php
+++ b/classes/upload_libraries_form.php
@@ -69,11 +69,18 @@ class upload_libraries_form extends \moodleform {
         );
         $mform->setType('disablefileextensioncheck', PARAM_BOOL);
         $mform->setDefault('disablefileextensioncheck', false);
-
-        $notification = $OUTPUT->notification(
-            get_string('disablefileextensioncheckwarning', 'hvp'),
-            'notifymessage'
-        );
+        if (!empty($CFG->mod_hvp_forcefileextensioncheck)) {
+            $mform->freeze('disablefileextensioncheck');
+            $notification = $OUTPUT->notification(
+                get_string('disablefileextensioncheckoverride', 'hvp'),
+                'notifymessage'
+            );
+        } else {
+            $notification = $OUTPUT->notification(
+                get_string('disablefileextensioncheckwarning', 'hvp'),
+                'notifymessage'
+            );
+        }
         $mform->addElement('static', '', '', $notification);
 
         // Upload button.

--- a/lang/en/hvp.php
+++ b/lang/en/hvp.php
@@ -124,6 +124,7 @@ $string['uploadlibraries'] = 'Upload Libraries';
 $string['options'] = 'Options';
 $string['onlyupdate'] = 'Only update existing libraries';
 $string['disablefileextensioncheck'] = 'Disable file extension check';
+$string['disablefileextensioncheckoverride'] = 'The option to disable the file extension check has been deactivated in config.php.';
 $string['disablefileextensioncheckwarning'] = "Warning! Disabling the file extension check may have security implications as it allows for uploading of php files. That in turn could make it possible for attackers to execute malicious code on your site. Please make sure you know exactly what you're uploading.";
 $string['upload'] = 'Upload';
 


### PR DESCRIPTION
By setting $CFG->mod_hvp_forcefileextensioncheck = true; in config.php, there is no way to check "Disable file extension check" in "Upload libraries" area any more.

Thank you for your interest in contributing to H5P! 🎉  
Please fill in the below sections to make your pull request:

**What kind of change does this PR introduce?**
Feature

**What is the current behaviour?**
All administrators can check the "Disable file extension check" checkbox in "Upload libraries" area.

**What is the new behaviour?**
If, in config.php, $CFG->mod_hvp_forcefileextensioncheck = true; is set, there is no possibility to
check the "Disable file extension check" checkbox in "Upload libraries" area any more.

## PR Checklist

Before submitting, please confirm:

- [X] I searched for existing issues/PRs first
- [X] I linked related issues/discussions
- [X] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.
