### PR TITLE
Correct width overriden Boost theme courses H5P editor, resolves #282.

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -55,7 +55,7 @@ class mod_hvp_mod_form extends moodleform_mod {
             array('maxbytes' => $COURSE->maxbytes, 'accepted_types' => '*'));
 
         // Editor placeholder.
-        if ($CFG->theme == 'boost' || in_array('boost', $PAGE->theme->parents)) {
+        if (($CFG->theme == 'boost' || $COURSE->theme == 'boost') || in_array('boost', $PAGE->theme->parents)) {
             $h5peditor   = [];
             $h5peditor[] = $mform->createElement('html',
                                                  '<div class="h5p-editor">' . get_string('javascriptloading', 'hvp') . '</div>');


### PR DESCRIPTION
Thank you for your interest in contributing to H5P! 🎉  
Please fill in the below sections to make your pull request:

**What kind of change does this PR introduce?**
Bug fix

**What is the current behaviour?**
(You can also link to an open issue here)
#282 

1. Navigate to Site Administration > Appearance > Themes > Theme Selector
2. Change the Site theme to anything other than Boost
3. Navigate to Site Administration > Appearance > Themes > Theme Settings
4. Place a check in the “Allow Course Themes” setting, and save changes
5. Create a new course. Default course settings are fine, just be sure to force the course theme to display Boost under the “Apperance” section.
6. Add an H5P activity to the course
7. In the H5P settings, the “Editor” section is displaying very narrowly making it difficult to read text depending on the selection chosen.

**What is the new behaviour?**
7. In the H5P settings, the “Editor” section is displaying in normal width as if there was Boost as Site theme.

## PR Checklist

Before submitting, please confirm:

- [X] I searched for existing issues/PRs first
- [X] I linked related issues/discussions
- [X] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.
