### PR TITLE
Replace require() with require_once(), resolves #377.

### DIFF
--- a/classes/user_grades.php
+++ b/classes/user_grades.php
@@ -25,7 +25,7 @@ namespace mod_hvp;
 
 defined('MOODLE_INTERNAL') || die();
 
-require(__DIR__ . '/../lib.php');
+require_once(__DIR__ . '/../lib.php');
 
 /**
  * Handles grade storage for users


### PR DESCRIPTION
Thank you for your interest in contributing to H5P! 🎉  
Please fill in the below sections to make your pull request:

**What kind of change does this PR introduce?**
Bug fix

**What is the current behaviour?**
#377

**What is the new behaviour?**
include_once() instead of include() for lib.php

## PR Checklist

Before submitting, please confirm:

- [X] I searched for existing issues/PRs first
- [X] I linked related issues/discussions
- [X] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.
